### PR TITLE
Updated Dockerfile to create user with host UID/GID.

### DIFF
--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -33,12 +33,16 @@ RUN apt-get install -y ros-noetic-twist-mux
 RUN apt-get install -y ros-noetic-teleop-twist-joy
 RUN apt-get install -y ros-noetic-depthimage-to-laserscan
 
-# create a user
-ARG hostuser=kaiyu
+ARG hostuser
+ARG hostgroup
+ARG hostuid
+ARG hostgid
 
-RUN adduser --disabled-password --gecos '' $hostuser
+RUN echo Host user is $hostuser:$hostuser
+RUN groupadd --gid $hostgid $hostgroup
+RUN adduser --disabled-password --gecos '' --gid $hostgid --uid $hostuid $hostuser
 RUN adduser $hostuser sudo
-# Ensure sudo group users are not asked for a p3assword when using sudo command
+# Ensure sudo group users are not asked for a password when using sudo command
 # by ammending sudoers file
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> \
 /etc/sudoers

--- a/docker/build.noetic.sh
+++ b/docker/build.noetic.sh
@@ -11,7 +11,13 @@ fi
 . "../tools.sh"
 
 # parse args
-hostuser=$USER  # the user inside the container
+
+# UID/GID for the container user
+hostuser=$USER
+hostuid=$UID
+hostgroup=$(id -gn $hostuser)
+hostgid=$(id -g $hostuser)
+
 nvidia=""
 for arg in "$@"
 do
@@ -36,6 +42,9 @@ cd $PWD/../  # get to the root of the repository
 docker build -f Dockerfile.noetic${nvidia}\
        -t robotdev:noetic\
        --build-arg hostuser=$hostuser\
+       --build-arg hostgroup=$hostgroup\
+       --build-arg hostuid=$hostuid\
+       --build-arg hostgid=$hostgid\
        --rm\
        .
 # Explain the options above:


### PR DESCRIPTION
Try this out.  I think the issues were stemming from the container user always being created with the same UID/GID values (1000/1000).  If the user building the container has a different UID/GID, the files in the container won't appear as belonging to the container user.  

This fix should create the user based on the host's UID/GID as well as their name.  For example, if `ericbot` has UID/GID 1003 on the host machine, we need to create the user `ericbot` inside the container to also have UID and GID 1003--otherwise, the container user that happens to be called `ericbot` won't have permission to read the files.  

Try it out and let me know how it goes--I tested the user creation part, but I had to comment out all the ROS stuff to test on my system.  If it works, I'd recommend updating the other dockerfiles that have this issue as well.  